### PR TITLE
Implemented dynamic sites

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,4 +1,4 @@
 bd_mediapart_proxy:
-    resource: "@BDMediapartProxyBundle/Resources/config/routing.yml"
-    prefix:   /
+    resource: .
+    type: domain
 

--- a/app/console
+++ b/app/console
@@ -7,7 +7,7 @@
 
 set_time_limit(0);
 
-require_once __DIR__.'/bootstrap.php.cache';
+require_once __DIR__.'/autoload.php';
 require_once __DIR__.'/AppKernel.php';
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;

--- a/src/BD/MediapartProxyBundle/DependencyInjection/Factory/YamlSitesRoutesFinderFactory.php
+++ b/src/BD/MediapartProxyBundle/DependencyInjection/Factory/YamlSitesRoutesFinderFactory.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace BD\MediapartProxyBundle\DependencyInjection\Factory;
+
+use Symfony\Component\Finder\Finder;
+
+class YamlSitesRoutesFinderFactory
+{
+    public static function build( $directory )
+    {
+        $finder = new Finder();
+        return $finder->in( $directory )->files()->name( "*.yml" );
+    }
+}

--- a/src/BD/MediapartProxyBundle/Resources/config/services.yml
+++ b/src/BD/MediapartProxyBundle/Resources/config/services.yml
@@ -1,6 +1,8 @@
 parameters:
     bd_mediapart_proxy.mediapart_browser.class: BD\MediapartProxyBundle\Proxy\MediapartBrowser
     bd_mediapart_proxy.controller.feed_proxy.class: BD\MediapartProxyBundle\Controller\FeedProxyController
+    bd_mediapart_proxy.routing_request_listener.class: BD\MediapartProxyBundle\Routing\RoutingRequestListener
+    bd_mediapart_proxy.routing_loader.yaml_finder.factory_class: BD\MediapartProxyBundle\DependencyInjection\Factory\YamlSitesRoutesFinderFactory
 
 services:
     bd_mediapart_proxy.controller.feed_proxy:
@@ -10,3 +12,27 @@ services:
     bd_mediapart_proxy.mediapart_browser:
         class: %bd_mediapart_proxy.mediapart_browser.class%
         arguments: [%mediapart_login%, %mediapart_password%, %app_uri%, %mediapart_session_cookie_string%]
+
+    bd_mediapart_proxy.routing_loader:
+        class: BD\MediapartProxyBundle\Routing\SiteRoutingLoader
+        tags:
+            - { name: routing.loader }
+        arguments:
+            - @bd_mediapart_proxy.routing_loader.finder
+            - %app_uri%
+
+    # A pre-configured instance of the finder that locates site domain routing files
+    bd_mediapart_proxy.routing_loader.finder:
+        class: Symfony\Component\Finder\Finder
+        factory_class: %bd_mediapart_proxy.routing_loader.yaml_finder.factory_class%
+        factory_method: build
+        arguments: [@bd_mediapart_proxy.routing_loader.path_getter, %app_uri%]
+
+    # Direct call to the FileLocator's locate method
+    bd_mediapart_proxy.routing_loader.path_getter:
+        lazy: true
+        class: StdClass
+        factory_service: file_locator
+        factory_method: locate
+        arguments: ['@@BDMediapartProxyBundle/Resources/config/sites_routing/']
+

--- a/src/BD/MediapartProxyBundle/Resources/config/sites_routing/mediapart.yml
+++ b/src/BD/MediapartProxyBundle/Resources/config/sites_routing/mediapart.yml
@@ -1,8 +1,8 @@
-bd_mediapart_proxy_articles_feed:
+bd_mediapart_proxy.mediapart_articles_feed:
     path: /articles/feed
     defaults: { _controller: bd_mediapart_proxy.controller.feed_proxy:proxyArticlesFeedAction }
 
-bd_mediapart_proxy_article:
+bd_mediapart_proxy.mediapart_article:
     path: /journal/{uri}
     defaults: { _controller: bd_mediapart_proxy.controller.feed_proxy:proxyArticleAction }
     requirements:

--- a/src/BD/MediapartProxyBundle/Resources/doc/spec/mediapart.md
+++ b/src/BD/MediapartProxyBundle/Resources/doc/spec/mediapart.md
@@ -1,0 +1,3 @@
+# Specs for mediapart.fr
+
+TODO

--- a/src/BD/MediapartProxyBundle/Routing/SiteRoutingLoader.php
+++ b/src/BD/MediapartProxyBundle/Routing/SiteRoutingLoader.php
@@ -1,0 +1,53 @@
+<?php
+namespace BD\MediapartProxyBundle\Routing;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Config\Loader\Loader;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Routing\RouteCollection;
+
+class SiteRoutingLoader extends Loader
+{
+    /** @var \Symfony\Component\Finder\Finder */
+    private $finder;
+
+    /** @var string */
+    private $rootHost;
+
+    /**
+     * @param \Symfony\Component\Finder\Finder $finder
+     * @param string $rootHost
+     */
+    public function __construct( Finder $finder, $rootHost )
+    {
+        $this->finder = $finder;
+
+        $this->rootHost = parse_url( $rootHost, PHP_URL_HOST );
+    }
+
+    public function load( $resource, $type = null )
+    {
+        // YAO, a custom SiteDomainRouteCollection
+        $collection = new RouteCollection();
+
+        /** @var \Symfony\Component\Finder\SplFileInfo $file */
+        foreach ( $this->finder as $file )
+        {
+            $host = $file->getBasename( '.yml' ) . '.' . $this->rootHost;
+
+            /** @var RouteCollection $routes */
+            $routes = $this->import( $file->getPathName(), 'yaml' );
+            $routes->setHost( $host );
+
+            $collection->addCollection( $routes );
+        }
+
+        return $collection;
+    }
+
+    public function supports( $resource, $type = null )
+    {
+        return $type === 'domain';
+    }
+}


### PR DESCRIPTION
Multiple sites can now be proxied. Each site is "namespaces" within a subdomain.

Given an application hosted on `rpx.io` (naming attempt, stands for ReaderProXy) ?): mediapart and monde-diplomatique are made available at `mediapart.rpx.io` and `lmd.rpx.io`. To make this possible, a custom route loader loads one routing configuration file per Site, and limits all its routes to the Site's subdomain.

routing files must be placed in the `Resources/config/sites_routing/<site_name>.yml`. `site_name` will be used as the subdomain for this Site. Controllers and services are configured as usual.
## TODO
- [x] Move 3cbd5b3 (monde-diplomatique support) to #1
- [x] Merge to dev and not master. Delete and re-create ?
