### PR TITLE
Mediapart RSS feed URL were not replaced

### DIFF
--- a/src/BD/SiteReaderProxy/MediapartSiteBundle/MediapartConfiguration.php
+++ b/src/BD/SiteReaderProxy/MediapartSiteBundle/MediapartConfiguration.php
@@ -23,7 +23,7 @@ class MediapartConfiguration implements WebsiteConfiguration
 
     public function fixupRssLink( $rssLink )
     {
-        $link = str_replace( 'http://www.mediapart.fr/', $this->appUri, $rssLink );
+        $link = str_replace( 'https://www.mediapart.fr/', $this->appUri, $rssLink );
         $link .= '?onglet=full';
         return $link;
     }


### PR DESCRIPTION
## Description

In the RSS feed on mediapart, links were not replaced as now the RSS feed provides links with https.
## Test

Basic sanity on mediapart
